### PR TITLE
docs: add documentation route map to AI development guidelines

### DIFF
--- a/docs/backlog/ways-of-working/05-ai-development-guidelines.md
+++ b/docs/backlog/ways-of-working/05-ai-development-guidelines.md
@@ -9,6 +9,38 @@
 ## Doel
 Dit document beschrijft de richtlijnen voor AI-assisted development (GitHub Copilot Agent) binnen het VVE Tooling project. Alle AI-gegenereerde code moet voldoen aan dezelfde kwaliteitseisen als handgeschreven code.
 
+## Documentatie Routekaart (waar vind je wat?)
+Gebruik deze routekaart om snel de juiste documentatie te vinden voor AI-werkzaamheden, ontwerp en productbeslissingen.
+
+### 1. Startpunten
+- **Projectoverzicht**: `README.md` (root) – high-level intro, tech stack, en hoofdnavigatie door docs.
+- **Backlog-overzicht**: `docs/backlog/README.md` – epics, features, stories en procesdocumenten.
+- **Architectuur-index**: `docs/architecture/README.md` – technische kaders en besluiten.
+
+### 2. Product & Strategie
+- **Productrichting**: `docs/product/discovery/01-probleemdefinitie-productrichting.md`
+- **Strategie**: `docs/product/strategy/01-productstrategie-keuzes.md`
+- **Epics**: `docs/backlog/epics/`
+
+### 3. UX & UI
+- **UX flows & designs**: `docs/ux/design/`
+- **UX discovery & vraagstukken**: `docs/ux/discovery/`
+- **UI componenten**: `docs/ui/components/`
+- **Screenshots & naming**: `docs/screenshots/README.md`
+
+### 4. Backlog proces & templates
+- **Ways of working**: `docs/backlog/ways-of-working/`
+- **Story templates**: `docs/backlog/stories/`
+- **Implementatierapporten**: `docs/backlog/implementation-reports/`
+
+### 5. Onderzoek & Markt
+- **Marktonderzoek**: `docs/marktonderzoek/` (start: `docs/marktonderzoek/00-overzicht.md`)
+
+### 6. Code & runtime
+- **Frontend**: `frontend/` (Next.js)
+- **Backend**: `backend/` (FastAPI)
+- **Docs**: `docs/` (alle documentatie)
+
 ## Verplichte Testing Requirements
 
 ### 1. Unit Tests


### PR DESCRIPTION
### Motivation
- Clarify the documentation structure by providing a navigable route map inside the AI development guidelines. 
- Help contributors and AI workflows quickly locate product, UX, backlog, architecture and code references.

### Description
- Added a `Documentatie Routekaart (waar vind je wat?)` section to `docs/backlog/ways-of-working/05-ai-development-guidelines.md`.
- The new section contains six subsections (Startpunten, Product & Strategie, UX & UI, Backlog proces & templates, Onderzoek & Markt, Code & runtime) with paths to core docs. 
- Provided direct links and example paths such as `README.md`, `docs/architecture/README.md`, `docs/product/...`, `docs/ux/...`, `docs/backlog/...`, `docs/marktonderzoek/`, `frontend/`, and `backend/`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a01cdba34832c99b079ff34229026)