### PR TITLE
Use nonstandard dev ports for db and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,29 @@ API docs: http://localhost:8000/docs
 ### Frontend
 ```bash
 cd frontend
+cp .env.example .env.local
 npm install
 npm run dev
 ```
 App: http://localhost:3000
+
+### Omgevingsvariabelen (deployment)
+Voor het online zetten van een omgeving configureer je de technische variabelen in `.env` bestanden.
+
+**Backend (./backend/.env)**
+- `DATABASE_URL` óf de losse `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_NAME`, `DATABASE_USER`, `DATABASE_PASSWORD`.
+- `ALLOWED_ORIGINS` met je frontend URL(s).
+- `COGNITO_*` en `JWT_*` afhankelijk van je auth-keuze.
+
+**Frontend (./frontend/.env.local)**
+- `NEXT_PUBLIC_API_URL` met de publieke backend URL.
+
+### Docker Compose (dev)
+```bash
+cp backend/.env.example backend/.env
+docker compose -f docker-compose.dev.yml up --build
+```
+Frontend draait op http://localhost:81 en backend op http://localhost:7001/docs.
 
 ## 🧪 Tests
 ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,7 +12,13 @@ API_PREFIX=/api/v1
 ALLOWED_ORIGINS=["http://localhost:3000"]
 
 # Database (PostgreSQL)
-DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/vvetooling
+# Use DATABASE_URL or the individual DATABASE_* settings below
+DATABASE_URL=
+DATABASE_HOST=localhost
+DATABASE_PORT=5432
+DATABASE_NAME=vvetooling
+DATABASE_USER=postgres
+DATABASE_PASSWORD=postgres
 
 # Authentication (AWS Cognito - for production)
 COGNITO_REGION=eu-central-1

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,6 +4,7 @@ Based on ADR-001 (Authentication & Authorization) and ADR-003 (Multi-tenancy).
 """
 
 from functools import lru_cache
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
 
@@ -24,7 +25,12 @@ class Settings(BaseSettings):
     ]
 
     # Database (PostgreSQL - ADR-003)
-    database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/vvetooling"
+    database_url: str | None = None
+    database_host: str = "localhost"
+    database_port: int = 5432
+    database_name: str = "vvetooling"
+    database_user: str = "postgres"
+    database_password: str = "postgres"
     database_pool_size: int = 10
     database_max_overflow: int = 20
 
@@ -54,6 +60,18 @@ class Settings(BaseSettings):
         env_file = ".env"
         env_file_encoding = "utf-8"
         case_sensitive = False
+
+    @model_validator(mode="after")
+    def build_database_url(self) -> "Settings":
+        """Construct DATABASE_URL from individual database settings when missing."""
+        if self.database_url:
+            return self
+        self.database_url = (
+            "postgresql+asyncpg://"
+            f"{self.database_user}:{self.database_password}"
+            f"@{self.database_host}:{self.database_port}/{self.database_name}"
+        )
+        return self
 
 
 @lru_cache

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,50 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: vvetooling
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "7000:5432"
+    volumes:
+      - vvetooling_db:/var/lib/postgresql/data
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
+    env_file:
+      - ./backend/.env
+    environment:
+      DATABASE_HOST: db
+      DATABASE_PORT: 5432
+      DATABASE_NAME: vvetooling
+      DATABASE_USER: postgres
+      DATABASE_PASSWORD: postgres
+      ALLOWED_ORIGINS: '["http://localhost:81"]'
+    ports:
+      - "7001:8000"
+    volumes:
+      - ./backend:/app
+    depends_on:
+      - db
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:7001/api/v1
+    ports:
+      - "81:3000"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    depends_on:
+      - backend
+
+volumes:
+  vvetooling_db:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# VVE Tooling Frontend - Environment Variables
+# Copy this file to .env.local (Next.js convention) and update with your values
+
+# API base URL for the backend
+NEXT_PUBLIC_API_URL=http://localhost:8000/api/v1

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev", "--", "--hostname", "0.0.0.0", "--port", "3000"]


### PR DESCRIPTION
### Motivation
- Avoid port collisions in a developer environment by using nonstandard host ports for the dev Postgres and backend services. 
- Ensure the frontend points to the adjusted backend port and update docs to avoid confusion when using the dev compose stack.

### Description
- Updated `docker-compose.dev.yml` to map Postgres host port `7000` to container `5432` and map backend host port `7001` to container `8000`.
- Adjusted the frontend service in `docker-compose.dev.yml` and `frontend` environment variable to use `NEXT_PUBLIC_API_URL=http://localhost:7001/api/v1`.
- Updated `README.md` to document that the frontend runs on `http://localhost:81` and the backend docs are available at `http://localhost:7001/docs`.

### Testing
- No automated tests were executed in this environment; `docker compose` validation and container-based checks were not run because Docker is unavailable here.
- No unit or integration test suites (`pytest` / `npm test`) were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a0bbea8a4832cab0f6f95d075b3cc)