### PR TITLE
Seed dev admin account on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ docker compose -f docker-compose.dev.yml up --build
 ```
 Frontend draait op http://localhost:81 en backend op http://localhost:7001/docs.
 
+De dev-omgeving seed automatisch een beheerder:
+- **E-mail:** `admin@vvetooling.local`
+- **Wachtwoord:** `Admin123!`
+- **VVE:** `VVETooling Demo VVE`
+
+Je kunt deze waarden overschrijven met `DEV_ADMIN_EMAIL`, `DEV_ADMIN_PASSWORD`,
+`DEV_ADMIN_FIRST_NAME`, `DEV_ADMIN_LAST_NAME` en `DEV_ADMIN_VVE_NAME` in je backend
+omgeving.
+
 ## 🧪 Tests
 ```bash
 cd backend

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -46,6 +46,13 @@ class Settings(BaseSettings):
     jwt_access_token_expire_minutes: int = 30
     jwt_refresh_token_expire_days: int = 7
 
+    # Development admin seed user
+    dev_admin_email: str = "admin@vvetooling.local"
+    dev_admin_password: str = "Admin123!"
+    dev_admin_first_name: str = "Dev"
+    dev_admin_last_name: str = "Admin"
+    dev_admin_vve_name: str = "VVETooling Demo VVE"
+
     # AWS S3 Storage (Document Storage - FEAT-011)
     s3_bucket_name: str = "vvetooling-documents"
     s3_region: str = "eu-central-1"

--- a/backend/app/db/dev_seed.py
+++ b/backend/app/db/dev_seed.py
@@ -1,0 +1,69 @@
+"""Seed development data for local environments."""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+
+from app.core.config import get_settings
+from app.core.security import UserRole, get_password_hash
+from app.db.models.models import User, VVE, VVEMember
+from app.db.session import async_session_maker
+
+logger = logging.getLogger(__name__)
+
+
+async def ensure_dev_admin() -> None:
+    """Ensure a default admin user and VVE exist in development."""
+    settings = get_settings()
+    if settings.environment != "development":
+        return
+
+    async with async_session_maker() as session:
+        async with session.begin():
+            user_result = await session.execute(
+                select(User).where(User.email == settings.dev_admin_email)
+            )
+            user = user_result.scalar_one_or_none()
+            if user is None:
+                user = User(
+                    email=settings.dev_admin_email,
+                    hashed_password=get_password_hash(
+                        settings.dev_admin_password
+                    ),
+                    first_name=settings.dev_admin_first_name,
+                    last_name=settings.dev_admin_last_name,
+                    is_active=True,
+                    is_email_verified=True,
+                )
+                session.add(user)
+                await session.flush()
+
+            vve_result = await session.execute(
+                select(VVE).where(VVE.name == settings.dev_admin_vve_name)
+            )
+            vve = vve_result.scalar_one_or_none()
+            if vve is None:
+                vve = VVE(name=settings.dev_admin_vve_name, is_active=True)
+                session.add(vve)
+                await session.flush()
+
+            membership_result = await session.execute(
+                select(VVEMember).where(
+                    VVEMember.user_id == user.id,
+                    VVEMember.vve_id == vve.id,
+                )
+            )
+            membership = membership_result.scalar_one_or_none()
+            if membership is None:
+                session.add(
+                    VVEMember(
+                        user_id=user.id,
+                        vve_id=vve.id,
+                        role=UserRole.BEHEERDER,
+                        is_active=True,
+                    )
+                )
+
+    logger.info("Dev admin ensured for %s", settings.dev_admin_email)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.routes import auth, transactions, units, contributions, documents, budgets, audit, tickets, splitsingsakte, email, contracts, meetings, mjop, compliance, voting, privacy, analytics
 from app.core.config import get_settings
+from app.db.dev_seed import ensure_dev_admin
 
 settings = get_settings()
 
@@ -69,6 +70,11 @@ def create_app() -> FastAPI:
     app.include_router(voting.router, prefix=api_prefix)
     app.include_router(privacy.router, prefix=api_prefix)
     app.include_router(analytics.router, prefix=api_prefix)
+
+    @app.on_event("startup")
+    async def seed_dev_data() -> None:
+        """Seed development data on startup."""
+        await ensure_dev_admin()
 
     @app.get("/health", tags=["system"])
     async def health_check() -> dict[str, str]:


### PR DESCRIPTION
### Motivation
- Make local development easier by ensuring a usable admin account and a demo VVE are present automatically when running the backend in the `development` environment.
- Provide sane, configurable defaults and document the credentials so contributors can quickly boot the system and exercise admin flows.

### Description
- Add new settings for dev admin defaults (`dev_admin_email`, `dev_admin_password`, `dev_admin_first_name`, `dev_admin_last_name`, `dev_admin_vve_name`) in `backend/app/core/config.py` so values can be overridden via environment variables.
- Add `backend/app/db/dev_seed.py` implementing `ensure_dev_admin()` which creates the admin `User`, a demo `VVE` and a `VVEMember` with role `BEHEERDER` when missing, using the existing `async_session_maker` and password hashing utilities.
- Invoke `ensure_dev_admin()` on FastAPI startup in `backend/app/main.py` guarded to run only when `settings.environment == "development"`.
- Document the default dev admin credentials and the environment variable overrides in `README.md` and show the default values (`admin@vvetooling.local` / `Admin123!` / `VVETooling Demo VVE`).

### Testing
- No automated tests were executed as part of this change (no CI/test run was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a12776238832ca62e18881dbf0c38)