### PR TITLE
Switch to pbkdf2_sha256 for password hashing; add DB init and safer dev seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Meer screenshots en naming conventies vind je in [docs/screenshots/README.md](do
 cd backend
 cp .env.example .env
 python -m pip install -r requirements.txt
+python -m app.db.init_db
 uvicorn app.main:app --reload
 ```
 API docs: http://localhost:8000/docs
@@ -81,6 +82,11 @@ cp backend/.env.example backend/.env
 docker compose -f docker-compose.dev.yml up --build
 ```
 Frontend draait op http://localhost:81 en backend op http://localhost:7001/docs.
+
+Als de database nog geen tabellen heeft, maak ze handmatig aan in de backend container:
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m app.db.init_db
+```
 
 De dev-omgeving seed automatisch een beheerder:
 - **E-mail:** `admin@vvetooling.local`

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -16,7 +16,7 @@ from app.core.config import get_settings
 settings = get_settings()
 
 # Password hashing context
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 
 
 class UserRole(str, Enum):
@@ -41,7 +41,7 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 
 
 def get_password_hash(password: str) -> str:
-    """Hash a password using bcrypt."""
+    """Hash a password using pbkdf2_sha256."""
     return pwd_context.hash(password)
 
 

--- a/backend/app/db/dev_seed.py
+++ b/backend/app/db/dev_seed.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 
+from asyncpg.exceptions import UndefinedTableError
 from sqlalchemy import select
+from sqlalchemy.exc import ProgrammingError
 
 from app.core.config import get_settings
 from app.core.security import UserRole, get_password_hash
@@ -20,50 +22,60 @@ async def ensure_dev_admin() -> None:
     if settings.environment != "development":
         return
 
-    async with async_session_maker() as session:
-        async with session.begin():
-            user_result = await session.execute(
-                select(User).where(User.email == settings.dev_admin_email)
-            )
-            user = user_result.scalar_one_or_none()
-            if user is None:
-                user = User(
-                    email=settings.dev_admin_email,
-                    hashed_password=get_password_hash(
-                        settings.dev_admin_password
-                    ),
-                    first_name=settings.dev_admin_first_name,
-                    last_name=settings.dev_admin_last_name,
-                    is_active=True,
-                    is_email_verified=True,
+    try:
+        async with async_session_maker() as session:
+            async with session.begin():
+                user_result = await session.execute(
+                    select(User).where(User.email == settings.dev_admin_email)
                 )
-                session.add(user)
-                await session.flush()
-
-            vve_result = await session.execute(
-                select(VVE).where(VVE.name == settings.dev_admin_vve_name)
-            )
-            vve = vve_result.scalar_one_or_none()
-            if vve is None:
-                vve = VVE(name=settings.dev_admin_vve_name, is_active=True)
-                session.add(vve)
-                await session.flush()
-
-            membership_result = await session.execute(
-                select(VVEMember).where(
-                    VVEMember.user_id == user.id,
-                    VVEMember.vve_id == vve.id,
-                )
-            )
-            membership = membership_result.scalar_one_or_none()
-            if membership is None:
-                session.add(
-                    VVEMember(
-                        user_id=user.id,
-                        vve_id=vve.id,
-                        role=UserRole.BEHEERDER,
+                user = user_result.scalar_one_or_none()
+                if user is None:
+                    user = User(
+                        email=settings.dev_admin_email,
+                        hashed_password=get_password_hash(
+                            settings.dev_admin_password
+                        ),
+                        first_name=settings.dev_admin_first_name,
+                        last_name=settings.dev_admin_last_name,
                         is_active=True,
+                        is_email_verified=True,
+                    )
+                    session.add(user)
+                    await session.flush()
+
+                vve_result = await session.execute(
+                    select(VVE).where(VVE.name == settings.dev_admin_vve_name)
+                )
+                vve = vve_result.scalar_one_or_none()
+                if vve is None:
+                    vve = VVE(name=settings.dev_admin_vve_name, is_active=True)
+                    session.add(vve)
+                    await session.flush()
+
+                membership_result = await session.execute(
+                    select(VVEMember).where(
+                        VVEMember.user_id == user.id,
+                        VVEMember.vve_id == vve.id,
                     )
                 )
+                membership = membership_result.scalar_one_or_none()
+                if membership is None:
+                    session.add(
+                        VVEMember(
+                            user_id=user.id,
+                            vve_id=vve.id,
+                            role=UserRole.BEHEERDER,
+                            is_active=True,
+                        )
+                    )
+    except ProgrammingError as exc:
+        if isinstance(exc.orig, UndefinedTableError):
+            logger.warning(
+                "Skipping dev seed because database schema is missing. "
+                "Run migrations or initialize tables.",
+                exc_info=exc,
+            )
+            return
+        raise
 
     logger.info("Dev admin ensured for %s", settings.dev_admin_email)

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -1,0 +1,31 @@
+"""Initialize database tables for development and local environments."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from app.db.models import models as _models  # noqa: F401
+from app.db.session import Base, engine
+
+logger = logging.getLogger(__name__)
+
+
+async def init_db(async_engine: AsyncEngine) -> None:
+    """Create all tables using SQLAlchemy metadata."""
+    async with async_engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+
+def main() -> None:
+    """Run database initialization as a script."""
+    logging.basicConfig(level=logging.INFO)
+    logger.info("Creating database tables...")
+    asyncio.run(init_db(engine))
+    logger.info("Database tables created.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Avoid bcrypt backend/runtime failures in the test environment by using a hashing algorithm that does not rely on the missing bcrypt backend implementation. 
- Prevent development startup crashes when the database schema is not present by exposing an explicit table-initialization script. 
- Make the dev seeding path robust by only skipping seeding when the error indicates missing tables, and surface other DB errors.

### Description
- Change password hashing to `pbkdf2_sha256` in `backend/app/core/security.py` and update the docstring for `get_password_hash`. 
- Add `backend/app/db/init_db.py` which runs `Base.metadata.create_all` against the async engine and can be invoked as a script. 
- Update `backend/app/db/dev_seed.py` to wrap the seed logic in a `try/except` and only suppress `ProgrammingError` when `exc.orig` is `asyncpg.exceptions.UndefinedTableError`, re-raising other database errors. 
- Document the `python -m app.db.init_db` usage in `README.md` and include a `docker compose` example to initialize tables inside the backend container.

### Testing
- Ran `cd backend && pytest tests/test_security.py tests/test_customer_journey_auth.py -q` which initially failed after switching to `bcrypt_sha256` due to bcrypt backend errors, so the hashing scheme was changed to `pbkdf2_sha256`. 
- After switching to `pbkdf2_sha256`, re-ran the same tests and they passed: `38 passed, 5 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a14541520832ca5152c125ca81b0e)