### PR TITLE
Skip dev seed when database is unavailable

### DIFF
--- a/backend/app/db/dev_seed.py
+++ b/backend/app/db/dev_seed.py
@@ -6,7 +6,7 @@ import logging
 
 from asyncpg.exceptions import UndefinedTableError
 from sqlalchemy import select
-from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from app.core.config import get_settings
 from app.core.security import UserRole, get_password_hash
@@ -68,6 +68,12 @@ async def ensure_dev_admin() -> None:
                             is_active=True,
                         )
                     )
+    except OperationalError as exc:
+        logger.warning(
+            "Skipping dev seed because database is unavailable.",
+            exc_info=exc,
+        )
+        return
     except ProgrammingError as exc:
         if isinstance(exc.orig, UndefinedTableError):
             logger.warning(


### PR DESCRIPTION
### Motivation
- The dev seeding routine ran at application startup and could fail if Postgres was still starting, preventing the backend container from becoming healthy.
- Make startup resilient by skipping the seed when the database is unreachable and logging a clear warning.

### Description
- Add `OperationalError` to imports in `backend/app/db/dev_seed.py` and catch it around the dev seed logic. 
- When an `OperationalError` occurs the seed now logs `"Skipping dev seed because database is unavailable."` with `exc_info` and returns early. 
- Preserve existing handling for `ProgrammingError`/`UndefinedTableError` which logs a schema-missing warning and re-raises other `ProgrammingError`s.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a19aee0d8832cb4b54cc6c966e71a)