### PR TITLE
Add healthchecks, internal network, and nginx reverse proxy to docker-compose.dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,8 +9,15 @@ services:
       POSTGRES_PASSWORD: postgres
     ports:
       - "7000:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d vvetooling"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     volumes:
       - vvetooling_db:/var/lib/postgresql/data
+    networks:
+      - vvetooling_net
 
   backend:
     build:
@@ -30,7 +37,19 @@ services:
     volumes:
       - ./backend:/app
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import socket; s=socket.socket(); s.settimeout(1); s.connect(('127.0.0.1',8000)); s.close()\"",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - vvetooling_net
 
   frontend:
     build:
@@ -38,13 +57,34 @@ services:
       dockerfile: Dockerfile.dev
     environment:
       NEXT_PUBLIC_API_URL: http://localhost:7001/api/v1
-    ports:
-      - "81:3000"
     volumes:
       - ./frontend:/app
       - /app/node_modules
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ > /dev/null"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - vvetooling_net
+
+  nginx:
+    image: nginx:1.25-alpine
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      frontend:
+        condition: service_healthy
+    networks:
+      - vvetooling_net
 
 volumes:
   vvetooling_db:
+
+networks:
+  vvetooling_net:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,14 @@
+server {
+  listen 80;
+  server_name _;
+
+  location / {
+    proxy_pass http://frontend:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}


### PR DESCRIPTION
### Motivation

- Ensure services start in a reliable order (db → backend → frontend → nginx) by using healthchecks and explicit dependency conditions.
- Isolate service traffic on an internal network and provide a single entrypoint so the frontend is reachable through a reverse proxy.

### Description

- Add service-level healthchecks to `db` (using `pg_isready`), `backend` (TCP connect test via Python), and `frontend` (HTTP probe via `wget`) in `docker-compose.dev.yml`.
- Replace the simple `depends_on` list with health-based conditions for `backend` and `frontend` and attach all services to the new `vvetooling_net` network in `docker-compose.dev.yml`.
- Remove the host port mapping for the frontend (`81:3000`) and add a new `nginx` service that maps `8080:80` and depends on the frontend being healthy.
- Add `nginx/default.conf` with a `proxy_pass http://frontend:3000;` configuration so nginx forwards HTTP traffic to the frontend container.

### Testing

- No automated tests were run against the modified compose config in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a1a87b494832c9e931edf839fd407)